### PR TITLE
Use `unsafeWindow`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,7 +22,7 @@ var gsPageMod = pageMod.PageMod({
     'http://listen.grooveshark.com/*',
     'http://preview.grooveshark.com/*'
   ],
-  contentScriptWhen: 'ready',
+  contentScriptWhen: 'end',
   contentScriptFile: data.url('pageMod.js'),
   onAttach: function onAttach(worker, mod) {
     if(!uiReady) {


### PR DESCRIPTION
Use `unsafeWindow` attribute in content script to make it work with a patched SDK 1.0, with patch from 660780.
